### PR TITLE
Fix regex to properly ignore comments

### DIFF
--- a/lib/Test/Mojibake.pm
+++ b/lib/Test/Mojibake.pm
@@ -200,7 +200,7 @@ sub file_encoding_ok {
             $pod = 1;
         } elsif ($pod == 0) {
             # source
-            $line =~ s/^\s*#.*$//sx;    # disclaimers placed in headers frequently contain UTF-8 *before* it's usage is declared.
+            $line =~ s/^\s*#.*$//s;    # disclaimers placed in headers frequently contain UTF-8 *before* its usage is declared.
             foreach (split m{;}x, $line) {
                 # trim
                 s/^\s+|\s+$//gsx;

--- a/t/good/ascii.pl
+++ b/t/good/ascii.pl
@@ -2,4 +2,5 @@
 use open ':locale';
 use strict;
 use warnings;
+# here is a comment containing ütf8 cháraçtërs, but we ignore these
 print "A noite, vovo Kowalsky ve o ima cair no pe do pinguim queixoso e vovo poe acucar no cha de tamaras do jabuti feliz.\n";

--- a/t/good/latin1.pl
+++ b/t/good/latin1.pl
@@ -2,4 +2,5 @@
 use open ':locale';
 use strict;
 use warnings;
+# here is a comment containing látïñ1 characters
 print "À noite, vovô Kowalsky vê o ímã cair no pé do pingüim queixoso e vovó põe açúcar no chá de tâmaras do jabuti feliz.\n";

--- a/t/good/utf8.pl_
+++ b/t/good/utf8.pl_
@@ -2,4 +2,5 @@
 use strict;
 use utf8::all;
 use warnings;
+# here is a comment containing ütf8 characters
 print "À noite, vovô Kowalsky vê o ímã cair no pé do pingüim queixoso e vovó põe açúcar no chá de tâmaras do jabuti feliz.\n";


### PR DESCRIPTION
The /x flag in regular expressions changes the semantics of `#` to indicate comments within the regular expression -- so comments weren't actually being ignored - as demonstrated by the additions to the tests.

I noticed you're using the /x modifier in most other pattern matches in the module, and should probably also be looked at.
