### PR TITLE
Handle the case where all_files_encoding_ok has no files to test by skipping all tests

### DIFF
--- a/lib/Test/Mojibake.pm
+++ b/lib/Test/Mojibake.pm
@@ -267,6 +267,11 @@ sub all_files_encoding_ok {
     ## no critic (ProhibitFiletest_f)
     my @files = map { -d $_ ? all_files($_) : (-f $_ ? $_ : ()) } @args;
 
+    unless (@files) {
+        $Test->plan(skip_all => 'could not find any files to test');
+        return;
+    }
+
     $Test->plan(tests => scalar @files);
 
     my $ok = 1;

--- a/t/08-all-files-none-found.t
+++ b/t/08-all-files-none-found.t
@@ -1,0 +1,23 @@
+#!perl -T
+use strict;
+use warnings qw(all);
+
+use Test::Builder::Tester tests => 1;
+use Test::More;
+
+use Test::Mojibake;
+
+ALL_FILES_NONE_FOUND: {
+    ## no critic (ProhibitNoWarnings)
+    no warnings qw(redefine);
+    my @plan;
+    *Test::Builder::plan = sub { shift; @plan = @_ };
+
+    all_files_encoding_ok(qw(t/_INEXISTENT_));
+
+    is_deeply(
+        \@plan,
+        [ skip_all => 'could not find any files to test' ],
+        'tests are skipped when there are no files to test'
+    );
+}


### PR DESCRIPTION
Previously this would call $Test->plan( tests => 0 ), which is an error. Now
it passes skip_all with an appropriate reason for skipping tests.