### PR TITLE
Add MetaJSON plugin [#12]

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -55,3 +55,4 @@ Unicode::CheckUTF8::PP = 0
 perl                = 5.006
 
 [ManifestSkip]
+[MetaJSON]


### PR DESCRIPTION
Adding the MetaJSON plugin to generate the missing `META.json` file.